### PR TITLE
Update documentation for Juju 3

### DIFF
--- a/docs/how-to/deploy_charmed_magma_orchestrator.md
+++ b/docs/how-to/deploy_charmed_magma_orchestrator.md
@@ -5,7 +5,7 @@
 The Orchestrator must be installed on a Kubernetes cluster with the following specifications:
 
 - **:material-kubernetes: Kubernetes**: A cluster with a total of a minimum of 6 vCPUs and 16 GB of RAM.
-- **:material-ubuntu: Juju**: A Juju controller with access to the Kubernetes cluster
+- **:material-ubuntu: Juju>=3**: A Juju controller with access to the Kubernetes cluster
 
 !!! note
 
@@ -53,7 +53,7 @@ juju scp --container="magma-orc8r-certifier" orc8r-certifier/0:/var/opt/magma/ce
 Retrieve the pfx package password:
 
 ```bash
-juju run-action orc8r-certifier/leader get-pfx-package-password --wait
+juju run orc8r-certifier/leader get-pfx-package-password
 ```
 
 !!! info
@@ -66,7 +66,7 @@ juju run-action orc8r-certifier/leader get-pfx-package-password --wait
 Retrieve the services that need to be exposed:
 
 ```bash
-juju run-action orc8r-orchestrator/leader get-load-balancer-services --wait
+juju run orc8r-orchestrator/leader get-load-balancer-services
 ```
 
 In your domain registrar, create A records for the following Kubernetes services:
@@ -83,7 +83,7 @@ In your domain registrar, create A records for the following Kubernetes services
 Get the master organization's username and password:
 
 ```bash
-juju run-action nms-magmalte/leader get-master-admin-credentials --wait
+juju run nms-magmalte/leader get-master-admin-credentials
 ```
 
 Confirm successful deployment by visiting `https://master.nms.<your domain>` and logging in

--- a/docs/how-to/integrate_charmed_magma_access_gateway_to_orchestrator.md
+++ b/docs/how-to/integrate_charmed_magma_access_gateway_to_orchestrator.md
@@ -17,7 +17,7 @@ juju relate magma-access-gateway-operator [[<controller>:]<user>/]<model-name>.o
 Fetch the Access Gateway's `Hardware ID` and `Challenge Key`:
 
 ```bash
-juju run-action magma-access-gateway-operator/<unit number> get-access-gateway-secrets --wait
+juju run magma-access-gateway-operator/<unit number> get-access-gateway-secrets
 ```
 
 Navigate to "Equipment" on the NMS via the left navigation bar, hit "Add Gateway" on the upper right, and fill out the multi-step modal form. Use the secrets from above for the "Hardware UUID" and "Challenge Key" fields.
@@ -27,7 +27,7 @@ Navigate to "Equipment" on the NMS via the left navigation bar, hit "Add Gateway
 Run the following command:
 
 ```bash
-juju run-action magma-access-gateway-operator/<unit number> post-install-checks --wait
+juju run magma-access-gateway-operator/<unit number> post-install-checks
 ```
 
 !!! info


### PR DESCRIPTION
Juju 3 changed the `run-action` command to `run` and waits by default. This PR updates the requirements to Juju 3 and updates the command to work on this new version.