### PR TITLE
Minor fixes and improvements for Charmed Magma's tutorial

### DIFF
--- a/docs/tutorial/03_deploying_magma_access_gateway.md
+++ b/docs/tutorial/03_deploying_magma_access_gateway.md
@@ -8,6 +8,7 @@ Create an AWS EC2 instance running Ubuntu 20.04:
 
 ```console
 aws ec2 run-instances \
+  --placement AvailabilityZone=us-east-2a \
   --security-group-ids <your security group ID> \
   --image-id ami-0568936c8d2b91c4e \
   --count 1 \
@@ -32,7 +33,7 @@ Note this address, you will need it very soon.
 Note the `SubnetId` and create a network interface on this subnet:
 
 ```console
-aws ec2 create-network-interface --subnet-id <your subnet ID> --group <your security group>
+aws ec2 create-network-interface --subnet-id <your subnet ID> --group <your security group> --tag-specifications 'ResourceType=network-interface,Tags=[{Key=Name,Value=agw-s1}]'
 ```
 
 Note the `NetworkInterfaceId` and use it to attach the network interface to the EC2 instance:
@@ -56,7 +57,7 @@ juju add-model edge aws/us-east-2
 Wait for the instance to boot up and be accessible via SSH, then add it as a Juju machine:
 
 ```console
-juju add-machine --private-key=<path to your private key> ssh:ubuntu@<EC2 instance IP address>
+juju add-machine --private-key=<path to your private key> ssh:ubuntu@<EC2 instance public IP address>
 ```
 
 Note the Juju machine ID and deploy Magma Access Gateway to it:
@@ -65,7 +66,7 @@ Note the Juju machine ID and deploy Magma Access Gateway to it:
 juju deploy magma-access-gateway-operator --config sgi=eth0 --config s1=eth1 --to <Machine ID>
 ```
 
-You can see the deployment's status by running `juju status`. The deployment is completed when the application is in the `Active-Idle` state. 
+You can see the deployment's status by running `juju status`. The deployment is completed when the application is in the `Active-Idle` state.
 
 ```console
 ubuntu@host:~$ juju status
@@ -73,10 +74,10 @@ Model  Controller     Cloud/Region   Version  SLA          Timestamp
 edge   aws-us-east-2  aws/us-east-2  2.9.42   unsupported  11:41:52Z
 
 App                            Version  Status  Scale  Charm                          Channel  Rev  Exposed  Message
-magma-access-gateway-operator           active      1  magma-access-gateway-operator  stable    29  no       
+magma-access-gateway-operator           active      1  magma-access-gateway-operator  stable    29  no
 
 Unit                              Workload  Agent  Machine  Public address  Ports  Message
-magma-access-gateway-operator/0*  active    idle   0        18.188.161.66          
+magma-access-gateway-operator/0*  active    idle   0        18.188.161.66
 
 Machine  State    Address        Inst id               Series  AZ  Message
 0        started  18.188.161.66  manual:18.188.161.66  focal       Manually provisioned machine

--- a/docs/tutorial/05_deploying_the_radio_simulator.md
+++ b/docs/tutorial/05_deploying_the_radio_simulator.md
@@ -7,6 +7,7 @@ Create an AWS EC2 instance running Ubuntu 20.04:
 ```console
 aws ec2 run-instances \
   --security-group-ids <your security group> \
+  --placement AvailabilityZone=us-east-2a \
   --image-id ami-0568936c8d2b91c4e \
   --count 1 \
   --instance-type t2.xlarge \
@@ -22,7 +23,7 @@ Replace the security group ID with one that allows SSH access and note the insta
 Using the same **S1** subnet that was created during step 3, create a new network interface:
 
 ```console
-aws ec2 create-network-interface --subnet-id <your subnet ID> --group <your security group>
+aws ec2 create-network-interface --subnet-id <your subnet ID> --group <your security group> --tag-specifications 'ResourceType=network-interface,Tags=[{Key=Name,Value=radio-simulator-s1}]'
 ```
 
 Attach the network interface to the EC2 instance:
@@ -36,7 +37,7 @@ aws ec2 attach-network-interface --network-interface-id <your network interface 
 Wait for the instance to boot up and be accessible via SSH, then add it as a Juju machine:
 
 ```console
-juju add-machine --private-key=<path to your private key> ssh:ubuntu@<EC2 instance IP address>
+juju add-machine --private-key=<path to your private key> ssh:ubuntu@<EC2 instance public IP address>
 ```
 
 ## Configure Netplan to use the secondary network interface
@@ -48,6 +49,7 @@ juju ssh <Your instance ID>
 ```
 
 Retrieve the mac address used by `eth1`:
+
 ```console
 ip a show eth1
 ```
@@ -69,7 +71,7 @@ network:
 Apply the netplan configuration:
 
 ```console
-netplan apply
+sudo netplan apply
 ```
 
 ## Deploy the srsRAN radio simulator

--- a/docs/tutorial/06_simulating_user_traffic.md
+++ b/docs/tutorial/06_simulating_user_traffic.md
@@ -4,37 +4,37 @@
 
 Create an Access Point Name (APN) in Magma Orchestrator:
 
-1. Login to `https://magma-test.<your domain>`
+1. Login to `https://magma-test.nms.<your domain>`
 2. Click on "Traffic" on the left panel
 3. Click on "APNs"
 4. Click on "Create New APN"
 5. Fill in the following values:
-      * APN ID: `default`
-      * Class ID: `9`
-      * ARP Priority Level: `15`
-      * Max Required Bandwidth
-           * Upload: `1000000`
-           * Download: `1000000`
-   * ARP Pre-emption-Capability: `Disabled`
-   * ARP Pre-emption-Vulnerability: `Disabled`
+   - APN ID: `default`
+   - Class ID: `9`
+   - ARP Priority Level: `15`
+   - Max Required Bandwidth
+     - Upload: `1000000`
+     - Download: `1000000`
+   - ARP Pre-emption-Capability: `Disabled`
+   - ARP Pre-emption-Vulnerability: `Disabled`
 6. Click on "Save"
 
-## Add a network subscriber 
+## Add a network subscriber
 
 Add a subscriber to the network in Magma Orchestrator:
 
-1. Login to `https://magma-test.<your domain>`
+1. Login to `https://magma-test.nms.<your domain>`
 2. Click on "Subscriber" on the left panel
-3. Click on "Add Subscriber"
+3. Click on "Add Subscribers"
 4. Click on "Add"
 5. Fill in the following values:
-    * Subscriber Name: `IMSI001010000000001`
-    * IMSI: `IMSI001010000000001`
-    * Auth Key: `00112233445566778899aabbccddeeff`
-    * Auth OPC: `63BFA50EE6523365FF14C1F45F88737D`
-    * Service: `ACTIVE`
-    * Data Plan: `default`
-    * Active APNs: `default`
+   - Subscriber Name: `IMSI001010000000001`
+   - IMSI: `IMSI001010000000001`
+   - Auth Key: `00112233445566778899aabbccddeeff`
+   - Auth OPC: `63BFA50EE6523365FF14C1F45F88737D`
+   - Service: `ACTIVE`
+   - Data Plan: `default`
+   - Active APNs: `default`
 6. Click on "Save"
 7. Click on "Save and Add Subscribers"
 
@@ -61,4 +61,4 @@ ping -I tun_srsue google.com
 ```
 
 !!!success Congratulations
-      You have a fully functioning 4G Network :partying_face:
+You have a fully functioning 4G Network :partying_face:


### PR DESCRIPTION
Fixes issue in Charmed Magma's tutorial. There's the possibility for any machine requiring an additional ENI to not be in the same AZ as the ENI, thus, making it impossible to attach. This PR solves this issue and adds minor improvements.