### PR TITLE
Adding .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: dirhtml
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# Optionally declare the Python requirements for building your docs
+python:
+  install:
+    - requirements: docs/.sphinx/requirements.txt


### PR DESCRIPTION
Adds `.readthedocs.yaml` to replace the config from RTD's Admin -> Advanced Settings section.
Missing `.readthedocs.yaml` causes RTD sending warning emails.
Change requested by @lblythen 